### PR TITLE
Fix bug that empty user_map should synchronize all bugs

### DIFF
--- a/.github/workflows/snap-test.yaml
+++ b/.github/workflows/snap-test.yaml
@@ -23,7 +23,7 @@ jobs:
         id: build-snap
 
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lp-to-jira-snap
           path: ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/snap-test.yaml
+++ b/.github/workflows/snap-test.yaml
@@ -11,9 +11,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -25,6 +32,6 @@ jobs:
       - name: Upload snap artifact
         uses: actions/upload-artifact@v4
         with:
-          name: lp-to-jira-snap
+          name: lp-to-jira-snap-${{ matrix.arch }}
           path: ${{ steps.build-snap.outputs.snap }}
           retention-days: 30

--- a/.github/workflows/snap-test.yaml
+++ b/.github/workflows/snap-test.yaml
@@ -1,0 +1,28 @@
+name: Build Testing Snap
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build-snap
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: lp-to-jira-snap
+          path: ${{ steps.build-snap.outputs.snap }}
+          retention-days: 30

--- a/.github/workflows/snap-test.yaml
+++ b/.github/workflows/snap-test.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -100,8 +100,7 @@ def get_all_lp_project_bug_tasks(lp, project, days=None, tags=None):
             'In Progress',
             'Fix Committed',
             'Fix Released'
-        ],
-        tags=tags
+        ]
     )
 
     return bug_tasks

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -206,7 +206,7 @@ def build_jira_issue(lp, bug, project_id, issue_type, assignee, component, opts=
         'project': project_id,
         'summary': 'LP#{} [{}] {}'.format(bug.id, bug_pkg, bug.title),
         'description': bug.description,
-        'assignee': { 'accountId': opts.user_map[assignee]},
+        'assignee': { 'accountId': opts.user_map[assignee] if assignee else None},
         'issuetype': {'name': issue_type}
     }
 
@@ -443,9 +443,6 @@ def main(args=None):
     elif opts.sync_project_bugs:
         sync_project = {"launchpad_project": opts.sync_project_bugs, "jira_project": opts.project, "assignees": None}
         opts.sync_project.append(sync_project)
-
-    # Ensure unassigned user maps
-    opts.user_map[None] = None
 
     if opts.merge_proposals:
         reviewers = list(opts.user_map.keys())

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -165,6 +165,10 @@ def get_first_matching_assignee(bug, assignees):
         for serie in bug.bug_tasks:
             if serie.assignee and (serie.assignee.name in assignees):
                 return serie.assignee.name, serie.status
+    else:
+        # If user_map is not defined. We still want to sync the status(first series) to JIRA
+        for serie in bug.bug_tasks:
+            return None, serie.status
  
     return None, None
 

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -273,8 +273,9 @@ def sync_milestone_to_jira(jira, bug, issue, project_id, dry_run=False):
             
             # Only update if the milestone is not already in fixVersions
             if milestone_name not in current_version_names:
+                # Convert existing version objects to dictionaries for JSON serialization
                 # Add the new version to fixVersions
-                new_versions = current_versions + [{'name': milestone_name}]
+                new_versions = [{'name': v.name} for v in current_versions] + [{'name': milestone_name}]
                 issue.update(fields={'fixVersions': new_versions})
                 print(f"Updated {issue.key} with milestone '{milestone_name}'")
         except Exception as e:

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -251,7 +251,7 @@ def ensure_jira_version(jira, project_id, version_name, dry_run=False):
             return None
 
 
-def sync_milestone_to_jira(jira, bug, issue, project_id, dry_run=False):
+def sync_milestone_to_jira(jira, bug, issue, project_id, dry_run=False, debug=False):
     """
     Sync Launchpad milestone to JIRA fixVersion.
     Creates the version in JIRA if it doesn't exist.
@@ -272,10 +272,11 @@ def sync_milestone_to_jira(jira, bug, issue, project_id, dry_run=False):
             current_version_names = [v.name for v in current_versions]
             
             # Debug: print current_versions to trace JSON serialization issue
-            print(f"DEBUG: current_versions = {current_versions}")
-            print(f"DEBUG: current_versions type = {type(current_versions)}")
-            if current_versions:
-                print(f"DEBUG: first version type = {type(current_versions[0])}")
+            if debug:
+                print(f"DEBUG: current_versions = {current_versions}")
+                print(f"DEBUG: current_versions type = {type(current_versions)}")
+                if current_versions:
+                    print(f"DEBUG: first version type = {type(current_versions[0])}")
             
             # Only update if the milestone is not already in fixVersions
             if milestone_name not in current_version_names:
@@ -347,7 +348,7 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
         update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, opts.dry_run)
         # Sync milestone to JIRA version if enabled
         if opts.sync_milestone:
-            sync_milestone_to_jira(jira, bug, issue, project_id, opts.dry_run)
+            sync_milestone_to_jira(jira, bug, issue, project_id, opts.dry_run, opts.debug)
         return
 
     sync_to_jira = False
@@ -380,7 +381,7 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
         jira_issue = create_jira_issue(jira, issue_dict, bug, opts)
         # Sync milestone to JIRA version if enabled
         if opts.sync_milestone:
-            sync_milestone_to_jira(jira, bug, jira_issue, project_id, opts.dry_run)
+            sync_milestone_to_jira(jira, bug, jira_issue, project_id, opts.dry_run, opts.debug)
 
     if opts.lp_link:
        if opts.dry_run:
@@ -514,6 +515,13 @@ def main(args=None):
         action='store_true',
         default=False,
         help='Sync Launchpad milestones to JIRA fix versions'
+    )
+    opt_parser.add_argument(
+        '--debug',
+        dest='debug',
+        action='store_true',
+        default=False,
+        help='Enable debug output messages'
     )
 
     opts = opt_parser.parse_args(args)

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -271,6 +271,12 @@ def sync_milestone_to_jira(jira, bug, issue, project_id, dry_run=False):
             current_versions = issue.fields.fixVersions if hasattr(issue.fields, 'fixVersions') else []
             current_version_names = [v.name for v in current_versions]
             
+            # Debug: print current_versions to trace JSON serialization issue
+            print(f"DEBUG: current_versions = {current_versions}")
+            print(f"DEBUG: current_versions type = {type(current_versions)}")
+            if current_versions:
+                print(f"DEBUG: first version type = {type(current_versions[0])}")
+            
             # Only update if the milestone is not already in fixVersions
             if milestone_name not in current_version_names:
                 # Convert existing version objects to dictionaries for JSON serialization

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -198,6 +198,91 @@ def update_bug_in_jira(jira, bug, issue, assignees, user_map, status_map, dry_ru
                     issue.update(fields=fields)
 
 
+def get_lp_bug_milestone(bug):
+    """
+    Extract milestone from a Launchpad bug.
+    Returns the milestone name if found, None otherwise.
+    """
+    milestone = None
+    
+    # Check bug tasks for milestone information
+    for task in bug.bug_tasks:
+        if hasattr(task, 'milestone') and task.milestone:
+            # Get milestone name
+            milestone = task.milestone.name
+            break
+    
+    return milestone
+
+
+def ensure_jira_version(jira, project_id, version_name, dry_run=False):
+    """
+    Ensure a JIRA version/release exists in the project.
+    Creates it if it doesn't exist.
+    Returns the version object or None.
+    """
+    if not version_name:
+        return None
+    
+    try:
+        # Check if version already exists
+        existing_version = jira.get_project_version_by_name(project_id, version_name)
+        if existing_version:
+            return existing_version
+    except Exception:
+        # Version doesn't exist, we'll create it
+        pass
+    
+    # Create the version if it doesn't exist
+    if dry_run:
+        print(f"(dry-run) Would create JIRA version '{version_name}' in project {project_id}")
+        return None
+    else:
+        try:
+            new_version = jira.create_version(
+                name=version_name,
+                project=project_id,
+                description=f"Synced from Launchpad milestone: {version_name}"
+            )
+            print(f"Created JIRA version '{version_name}' in project {project_id}")
+            return new_version
+        except Exception as e:
+            print(f"Failed to create JIRA version '{version_name}': {e}")
+            return None
+
+
+def sync_milestone_to_jira(jira, bug, issue, project_id, dry_run=False):
+    """
+    Sync Launchpad milestone to JIRA fixVersion.
+    Creates the version in JIRA if it doesn't exist.
+    """
+    milestone_name = get_lp_bug_milestone(bug)
+    
+    if not milestone_name:
+        # No milestone to sync
+        return
+    
+    # Ensure the version exists in JIRA
+    jira_version = ensure_jira_version(jira, project_id, milestone_name, dry_run)
+    
+    if jira_version and not dry_run:
+        try:
+            # Get current fix versions
+            current_versions = issue.fields.fixVersions if hasattr(issue.fields, 'fixVersions') else []
+            current_version_names = [v.name for v in current_versions]
+            
+            # Only update if the milestone is not already in fixVersions
+            if milestone_name not in current_version_names:
+                # Add the new version to fixVersions
+                new_versions = current_versions + [{'name': milestone_name}]
+                issue.update(fields={'fixVersions': new_versions})
+                print(f"Updated {issue.key} with milestone '{milestone_name}'")
+        except Exception as e:
+            print(f"Failed to update {issue.key} with milestone '{milestone_name}': {e}")
+    elif dry_run and milestone_name:
+        print(f"(dry-run) Would update {issue.key} with milestone '{milestone_name}'")
+
+
 def build_jira_issue(lp, bug, project_id, issue_type, assignee, component, opts=None):
     """Builds and return a dict to create a Jira Issue from"""
 
@@ -253,6 +338,8 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
     exists, issue = is_bug_in_jira(jira, bug, project_id)
     if exists:
         update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, opts.dry_run)
+        # Sync milestone to JIRA version
+        sync_milestone_to_jira(jira, bug, issue, project_id, opts.dry_run)
         return
 
     sync_to_jira = False
@@ -276,8 +363,14 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
 
     if opts.dry_run:
         print("(dry-run) Creating JIRA issue {}".format(issue_dict))
+        # Check for milestone in dry-run mode
+        milestone_name = get_lp_bug_milestone(bug)
+        if milestone_name:
+            print(f"(dry-run) Would sync milestone '{milestone_name}' to JIRA")
     else:
         jira_issue = create_jira_issue(jira, issue_dict, bug, opts)
+        # Sync milestone to JIRA version
+        sync_milestone_to_jira(jira, bug, jira_issue, project_id, opts.dry_run)
 
     if opts.lp_link:
        if opts.dry_run:

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -165,19 +165,19 @@ def is_bug_in_jira(jira, bug, project_id):
         return True, issues[0]
     return False, None
 
-def get_first_matching_assignee(bug, assignees, sync_all_statuses=False):
+def get_first_matching_assignee(bug, assignees, sync_unmapped_users=False):
     """Return the first assignee and status matching an entry in assignees.
 
-    If sync_all_statuses is True and user_map is supplied but no assignee
+    If sync_unmapped_users is True and user_map is supplied but no assignee
     match is found, fall back to returning (None, first_status) so that
-    status is still synced to JIRA.
+    unmapped users are still synced to JIRA with just the status.
     """
     if len(assignees) > 0:
         for serie in bug.bug_tasks:
             if serie.assignee and (serie.assignee.name in assignees):
                 return serie.assignee.name, serie.status
         # Mode 3: fall back to first task's status with no assignee
-        if sync_all_statuses and bug.bug_tasks:
+        if sync_unmapped_users and bug.bug_tasks:
             return None, bug.bug_tasks[0].status
     else:
         # If user_map is not defined. We still want to sync the status(first series) to JIRA
@@ -188,10 +188,10 @@ def get_first_matching_assignee(bug, assignees, sync_all_statuses=False):
 
 
 
-def update_bug_in_jira(jira, bug, issue, assignees, user_map, status_map, priority_map=None, dry_run=False, sync_all_statuses=False):
+def update_bug_in_jira(jira, bug, issue, assignees, user_map, status_map, priority_map=None, dry_run=False, sync_unmapped_users=False):
     """Update Jira status fields from Launchpad Bug"""
 
-    assignee, status = get_first_matching_assignee(bug, assignees, sync_all_statuses)
+    assignee, status = get_first_matching_assignee(bug, assignees, sync_unmapped_users)
     if status:
         status = status_map[status]
 
@@ -374,7 +374,7 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
 
     exists, issue = is_bug_in_jira(jira, bug, project_id)
     if exists:
-        update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, opts.priority_map, opts.dry_run, opts.sync_all_statuses)
+        update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, opts.priority_map, opts.dry_run, opts.sync_unmapped_users)
         # Sync milestone to JIRA version if enabled
         if opts.sync_milestone:
             sync_milestone_to_jira(jira, bug, issue, project_id, opts.dry_run, opts.debug)
@@ -386,7 +386,7 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
         # If no assignees specified, sync everything
         sync_to_jira = True
     else:
-        assignee, status = get_first_matching_assignee(bug, assignees, opts.sync_all_statuses)
+        assignee, status = get_first_matching_assignee(bug, assignees, opts.sync_unmapped_users)
         sync_to_jira = True if (assignee or status) else False
 
     if not sync_to_jira:
@@ -586,7 +586,7 @@ def main(args=None):
     opts.user_map = {}
     opts.priority_map = {}
     opts.sync_project = []
-    opts.sync_all_statuses = False
+    opts.sync_unmapped_users = False
 
     if opts.config:
         json_config = json.load(opts.config)
@@ -596,7 +596,7 @@ def main(args=None):
         opts.priority_map = json_config.get("priority_map", {})
         if "sync_milestone" in json_config:
             opts.sync_milestone = json_config["sync_milestone"]
-        opts.sync_all_statuses = json_config.get("sync_all_statuses", False)
+        opts.sync_unmapped_users = json_config.get("sync_unmapped_users", False)
     elif opts.sync_project_bugs:
         sync_project = {"launchpad_project": opts.sync_project_bugs, "jira_project": opts.project, "assignees": None}
         opts.sync_project.append(sync_project)

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -558,6 +558,8 @@ def main(args=None):
         opts.sync_project = json_config["project"]
         opts.status_map = json_config["status_map"]
         opts.user_map = json_config["user_map"]
+        if "sync_milestone" in json_config:
+            opts.sync_milestone = json_config["sync_milestone"]
     elif opts.sync_project_bugs:
         sync_project = {"launchpad_project": opts.sync_project_bugs, "jira_project": opts.project, "assignees": None}
         opts.sync_project.append(sync_project)

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -165,25 +165,33 @@ def is_bug_in_jira(jira, bug, project_id):
         return True, issues[0]
     return False, None
 
-def get_first_matching_assignee(bug, assignees):
-    """Return the first assignee and status matching an entry in assignees"""
+def get_first_matching_assignee(bug, assignees, sync_all_statuses=False):
+    """Return the first assignee and status matching an entry in assignees.
+
+    If sync_all_statuses is True and user_map is supplied but no assignee
+    match is found, fall back to returning (None, first_status) so that
+    status is still synced to JIRA.
+    """
     if len(assignees) > 0:
         for serie in bug.bug_tasks:
             if serie.assignee and (serie.assignee.name in assignees):
                 return serie.assignee.name, serie.status
+        # Mode 3: fall back to first task's status with no assignee
+        if sync_all_statuses and bug.bug_tasks:
+            return None, bug.bug_tasks[0].status
     else:
         # If user_map is not defined. We still want to sync the status(first series) to JIRA
         for serie in bug.bug_tasks:
             return None, serie.status
- 
+
     return None, None
 
 
 
-def update_bug_in_jira(jira, bug, issue, assignees, user_map, status_map, priority_map=None, dry_run=False):
+def update_bug_in_jira(jira, bug, issue, assignees, user_map, status_map, priority_map=None, dry_run=False, sync_all_statuses=False):
     """Update Jira status fields from Launchpad Bug"""
 
-    assignee, status = get_first_matching_assignee(bug, assignees)
+    assignee, status = get_first_matching_assignee(bug, assignees, sync_all_statuses)
     if status:
         status = status_map[status]
 
@@ -366,7 +374,7 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
 
     exists, issue = is_bug_in_jira(jira, bug, project_id)
     if exists:
-        update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, opts.priority_map, opts.dry_run)
+        update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, opts.priority_map, opts.dry_run, opts.sync_all_statuses)
         # Sync milestone to JIRA version if enabled
         if opts.sync_milestone:
             sync_milestone_to_jira(jira, bug, issue, project_id, opts.dry_run, opts.debug)
@@ -378,8 +386,8 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
         # If no assignees specified, sync everything
         sync_to_jira = True
     else:
-        assignee, status = get_first_matching_assignee(bug, assignees)
-        sync_to_jira = True if assignee else False
+        assignee, status = get_first_matching_assignee(bug, assignees, opts.sync_all_statuses)
+        sync_to_jira = True if (assignee or status) else False
 
     if not sync_to_jira:
         return
@@ -578,6 +586,7 @@ def main(args=None):
     opts.user_map = {}
     opts.priority_map = {}
     opts.sync_project = []
+    opts.sync_all_statuses = False
 
     if opts.config:
         json_config = json.load(opts.config)
@@ -587,6 +596,7 @@ def main(args=None):
         opts.priority_map = json_config.get("priority_map", {})
         if "sync_milestone" in json_config:
             opts.sync_milestone = json_config["sync_milestone"]
+        opts.sync_all_statuses = json_config.get("sync_all_statuses", False)
     elif opts.sync_project_bugs:
         sync_project = {"launchpad_project": opts.sync_project_bugs, "jira_project": opts.project, "assignees": None}
         opts.sync_project.append(sync_project)

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -282,7 +282,7 @@ def sync_milestone_to_jira(jira, bug, issue, project_id, dry_run=False, debug=Fa
             if milestone_name not in current_version_names:
                 # Convert existing version objects to dictionaries for JSON serialization
                 # Add the new version to fixVersions
-                new_versions = [{'name': v.name} for v in current_versions] + [{'name': milestone_name}]
+                new_versions = [{'name': milestone_name}]
                 issue.update(fields={'fixVersions': new_versions})
                 print(f"Updated {issue.key} with milestone '{milestone_name}'")
         except Exception as e:

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -53,6 +53,13 @@ def get_lp_bug(lp, bug_number):
     return bug
 
 
+def get_lp_bug_importance(bug):
+    """Return the importance of the first bug task, or None if unavailable"""
+    for task in bug.bug_tasks:
+        return task.importance
+    return None
+
+
 def get_lp_bug_pkg(bug):
     """
     From a LP bug, get its package
@@ -173,7 +180,7 @@ def get_first_matching_assignee(bug, assignees):
 
 
 
-def update_bug_in_jira(jira, bug, issue, assignees, user_map, status_map, dry_run=False):
+def update_bug_in_jira(jira, bug, issue, assignees, user_map, status_map, priority_map=None, dry_run=False):
     """Update Jira status fields from Launchpad Bug"""
 
     assignee, status = get_first_matching_assignee(bug, assignees)
@@ -196,6 +203,18 @@ def update_bug_in_jira(jira, bug, issue, assignees, user_map, status_map, dry_ru
                 elif meta == "assignee":
                     fields = {"assignee": {"accountId": lp_state["assignee"]}}
                     issue.update(fields=fields)
+
+    # Sync LP importance to JIRA priority if priority_map is configured
+    if priority_map:
+        importance = get_lp_bug_importance(bug)
+        if importance and importance in priority_map:
+            lp_priority = priority_map[importance]
+            jira_priority = issue.fields.priority.name if issue.fields.priority else None
+            if lp_priority != jira_priority:
+                print("Updating {} priority from {} -> {}".format(
+                    issue.key, jira_priority, lp_priority))
+                if not dry_run:
+                    issue.update(fields={"priority": {"name": lp_priority}})
 
 
 def get_lp_bug_milestone(bug):
@@ -306,6 +325,13 @@ def build_jira_issue(lp, bug, project_id, issue_type, assignee, component, opts=
     if component:
         issue_dict["components"] = [{"name": component}]
 
+    # Map LP importance to JIRA priority if priority_map is configured
+    priority_map = getattr(opts, 'priority_map', None) if opts else None
+    if isinstance(priority_map, dict) and priority_map:
+        importance = get_lp_bug_importance(bug)
+        if importance and importance in priority_map:
+            issue_dict['priority'] = {'name': priority_map[importance]}
+
     return issue_dict
 
 
@@ -341,7 +367,8 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
 
     exists, issue = is_bug_in_jira(jira, bug, project_id)
     if exists:
-        update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, opts.dry_run)
+        priority_map = opts.priority_map if isinstance(getattr(opts, 'priority_map', None), dict) else None
+        update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, priority_map, opts.dry_run)
         # Sync milestone to JIRA version if enabled
         if opts.sync_milestone:
             sync_milestone_to_jira(jira, bug, issue, project_id, opts.dry_run, opts.debug)
@@ -551,6 +578,7 @@ def main(args=None):
 
     opts.status_map = {}
     opts.user_map = {}
+    opts.priority_map = {}
     opts.sync_project = []
 
     if opts.config:
@@ -558,6 +586,7 @@ def main(args=None):
         opts.sync_project = json_config["project"]
         opts.status_map = json_config["status_map"]
         opts.user_map = json_config["user_map"]
+        opts.priority_map = json_config.get("priority_map", {})
         if "sync_milestone" in json_config:
             opts.sync_milestone = json_config["sync_milestone"]
     elif opts.sync_project_bugs:

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -278,13 +278,9 @@ def sync_milestone_to_jira(jira, bug, issue, project_id, dry_run=False, debug=Fa
                 if current_versions:
                     print(f"DEBUG: first version type = {type(current_versions[0])}")
             
-            # Only update if the milestone is not already in fixVersions
-            if milestone_name not in current_version_names:
-                # Convert existing version objects to dictionaries for JSON serialization
-                # Add the new version to fixVersions
-                new_versions = [{'name': milestone_name}]
-                issue.update(fields={'fixVersions': new_versions})
-                print(f"Updated {issue.key} with milestone '{milestone_name}'")
+            new_versions = [{'name': milestone_name}]
+            issue.update(fields={'fixVersions': new_versions})
+            print(f"Updated {issue.key} with milestone '{milestone_name}'")
         except Exception as e:
             print(f"Failed to update {issue.key} with milestone '{milestone_name}': {e}")
     elif dry_run and milestone_name:

--- a/LpToJira/lp_to_jira.py
+++ b/LpToJira/lp_to_jira.py
@@ -326,11 +326,10 @@ def build_jira_issue(lp, bug, project_id, issue_type, assignee, component, opts=
         issue_dict["components"] = [{"name": component}]
 
     # Map LP importance to JIRA priority if priority_map is configured
-    priority_map = getattr(opts, 'priority_map', None) if opts else None
-    if isinstance(priority_map, dict) and priority_map:
+    if opts and opts.priority_map:
         importance = get_lp_bug_importance(bug)
-        if importance and importance in priority_map:
-            issue_dict['priority'] = {'name': priority_map[importance]}
+        if importance and importance in opts.priority_map:
+            issue_dict['priority'] = {'name': opts.priority_map[importance]}
 
     return issue_dict
 
@@ -367,8 +366,7 @@ def lp_to_jira_bug(lp, jira, bug, sync, opts):
 
     exists, issue = is_bug_in_jira(jira, bug, project_id)
     if exists:
-        priority_map = opts.priority_map if isinstance(getattr(opts, 'priority_map', None), dict) else None
-        update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, priority_map, opts.dry_run)
+        update_bug_in_jira(jira, bug, issue, assignees, opts.user_map, opts.status_map, opts.priority_map, opts.dry_run)
         # Sync milestone to JIRA version if enabled
         if opts.sync_milestone:
             sync_milestone_to_jira(jira, bug, issue, project_id, opts.dry_run, opts.debug)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # lp-to-jira
-Python helper script that create a new JIRA bug entry from an existing Launchpad bug id
+Python helper script that create a new JIRA bug entry from an existing Launchpad bug ID.
 
 ## Launchpad
-https://launchpad.net/
-lp-to-jira will access launchpad as a anonymous user for now so private bug might not be visible
+lp-to-jira will access [Launchpad](https://launchpad.net/) as an anonymous user for now so private bug might not be visible.
 
 ## JIRA
-a JIRA account is required You will need to setup a JIRA token to access your server.
-On the first launch lp-to-jira will assist you in getting your jira API token.
-JIRA API token can be created here https://id.atlassian.com/manage-profile/security/api-tokens
+A JIRA account is required You will need to setup a JIRA token to access your server.
+
+On the first launch lp-to-jira will assist you in getting your jira API token. JIRA API token can be created here: https://id.atlassian.com/manage-profile/security/api-tokens.
 
 ## Usage:
 ```
@@ -56,8 +55,9 @@ Examples:
 ```
 
 # lp-to-jira-report
-Python helper script that produce reports listing all the bugs in a given project that have been imported with lp-to-jira
-(issues that have LP#1234567 in their titles)
+Python helper script that produces report listing all the bugs in a given project that have been imported with lp-to-jira.
+
+(issues that have LP #1234567 in their titles)  
 This report will show JIRA status for the issues and LP status for the related LP bugs in all impacted series.
 
 ## Usage:
@@ -89,9 +89,8 @@ Examples:
 usage: lp-to-jira-report [options] --sync project-id
 ```
 
-This will perform the same as lp-to-jira-report except that will also sync
-some fata from Launchpad back into your JIRA issues
+This will perform the same as `lp-to-jira-report` except that will also sync some data from Launchpad back into your JIRA issues.
 
-- Title Sync: If the Launchpad Item title changed, the JIRA issues summary will be updated
-- Rekease Status: If all the series impacted in Launchpad are Fix Release, the JIRA issue will automatically be moved to DONE
-- It is possible to disable automation on the JIRA issue by creating a Label called DisableLPSync
+- Title Sync: If the Launchpad Item title changed, the JIRA issues summary will be updated.
+- Release Status: If all the series impacted in Launchpad are Fix Released, the JIRA issue will automatically be moved to DONE.
+- It is possible to disable automation on the JIRA issue by creating a Label called DisableLPSync.

--- a/sample.json
+++ b/sample.json
@@ -1,5 +1,6 @@
 {
   "sync_milestone": false,
+  "sync_all_statuses": false,
   "status_map":
   {
     "New": "To Do",

--- a/sample.json
+++ b/sample.json
@@ -1,6 +1,6 @@
 {
   "sync_milestone": false,
-  "sync_all_statuses": false,
+  "sync_unmapped_users": false,
   "status_map":
   {
     "New": "To Do",

--- a/sample.json
+++ b/sample.json
@@ -1,4 +1,5 @@
 {
+  "sync_milestone": false,
   "status_map":
   {
     "New": "To Do",

--- a/sample.json
+++ b/sample.json
@@ -13,6 +13,16 @@
     "Fix Committed": "Done",
     "Fix Released": "Done"
   },
+  "priority_map":
+  {
+    "Critical": "Highest",
+    "High": "High",
+    "Medium": "Medium",
+    "Low": "Low",
+    "Wishlist": "Lowest",
+    "Undecided": "Medium",
+    "Unknown": "Medium"
+  },
   "user_map":
   {
     "userid00": "deadbeef01",

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 packages = find:
 install_requires =
     launchpadlib
-    jira
+    jira>=3.10.5
 
 [options.extras_require]
 test =

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: lp-to-jira
-base: core20
-version: '0.7'
+base: core24
+version: '0.8'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,3 +1,4 @@
+title: LaunchPad to Jira Bug Importer
 name: lp-to-jira
 base: core24
 version: '0.8'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ parts:
     stage-packages:
       - python3-wheel
     python-packages:
-      - jira == 3.0.1
+      - jira
       - launchpadlib
     source: .
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 title: LaunchPad to Jira Bug Importer
 name: lp-to-jira
 base: core24
-version: '0.9'
+version: '0.10'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: lp-to-jira
-base: core20
-version: '0.7'
+base: core24
+version: '0.8'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA
@@ -17,7 +17,7 @@ parts:
     stage-packages:
       - python3-wheel
     python-packages:
-      - jira == 3.0.1
+      - jira
       - launchpadlib
     source: .
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 title: LaunchPad to Jira Bug Importer
 name: lp-to-jira
 base: core24
-version: '0.8'
+version: '0.9'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 title: LaunchPad to Jira Bug Importer
 name: lp-to-jira
 base: core24
-version: '0.10'
+version: '0.11'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 title: LaunchPad to Jira Bug Importer
 name: lp-to-jira
 base: core24
-version: '0.12'
+version: '0.13'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 title: LaunchPad to Jira Bug Importer
 name: lp-to-jira
 base: core24
-version: '0.11'
+version: '0.12'
 summary: Command Line Interface to import Launchpad content into JIRA
 description: |
   lp-to-jira allows you to import bug from a launchpad project into a JIRA

--- a/tests/test_lp_to_jira.py
+++ b/tests/test_lp_to_jira.py
@@ -7,9 +7,11 @@ from LpToJira.lp_to_jira import\
     create_jira_issue,\
     get_lp_bug,\
     get_lp_bug_pkg,\
+    get_lp_bug_importance,\
     get_all_lp_project_bug_tasks,\
     is_bug_in_jira,\
-    lp_to_jira_bug
+    lp_to_jira_bug,\
+    update_bug_in_jira
 
 
 def test_get_lp_bug(lp):
@@ -159,3 +161,114 @@ def test_lp_to_jira_bug(lp, empty_bug):
         lp_to_jira_bug(lp, jira, empty_bug, config01, opts)
 
 # =============================================================================
+
+def test_get_lp_bug_importance():
+    bug = Mock()
+    bug.bug_tasks = [Mock(importance='Critical')]
+    assert get_lp_bug_importance(bug) == 'Critical'
+
+    bug = Mock()
+    bug.bug_tasks = [Mock(importance='High'), Mock(importance='Medium')]
+    assert get_lp_bug_importance(bug) == 'High'
+
+    bug = Mock()
+    bug.bug_tasks = []
+    assert get_lp_bug_importance(bug) is None
+
+
+def test_build_jira_issue_with_priority_map():
+    bug = Mock()
+    bug.id = 1
+    bug.title = "test bug"
+    bug.description = "test description"
+    bug.bug_tasks = [Mock(bug_target_name='systemd (Ubuntu)', importance='High')]
+
+    opts = Mock()
+    opts.user_map = {}
+    opts.priority_map = {'High': 'High', 'Critical': 'Highest'}
+
+    issue_dict = build_jira_issue(None, bug, 'PROJ', 'Bug', None, None, opts)
+    assert issue_dict.get('priority') == {'name': 'High'}
+
+
+def test_build_jira_issue_no_priority_map():
+    bug = Mock()
+    bug.id = 1
+    bug.title = "test bug"
+    bug.description = "test description"
+    bug.bug_tasks = [Mock(bug_target_name='systemd (Ubuntu)', importance='High')]
+
+    opts = Mock()
+    opts.user_map = {}
+    opts.priority_map = {}
+
+    issue_dict = build_jira_issue(None, bug, 'PROJ', 'Bug', None, None, opts)
+    assert 'priority' not in issue_dict
+
+
+def test_build_jira_issue_unmapped_importance():
+    bug = Mock()
+    bug.id = 1
+    bug.title = "test bug"
+    bug.description = "test description"
+    bug.bug_tasks = [Mock(bug_target_name='systemd (Ubuntu)', importance='Wishlist')]
+
+    opts = Mock()
+    opts.user_map = {}
+    opts.priority_map = {'High': 'High', 'Critical': 'Highest'}
+
+    issue_dict = build_jira_issue(None, bug, 'PROJ', 'Bug', None, None, opts)
+    assert 'priority' not in issue_dict
+
+
+def test_update_bug_in_jira_priority():
+    jira = Mock()
+    bug = Mock()
+    bug.bug_tasks = [Mock(importance='Critical', assignee=None, status='New')]
+
+    issue = Mock()
+    issue.key = 'TEST-1'
+    issue.fields.assignee = None
+    issue.fields.status.name = 'To Do'
+    issue.fields.priority.name = 'Medium'
+
+    priority_map = {'Critical': 'Highest', 'High': 'High'}
+    status_map = {'New': 'To Do'}
+
+    update_bug_in_jira(jira, bug, issue, [], {}, status_map, priority_map)
+    issue.update.assert_called_once_with(fields={'priority': {'name': 'Highest'}})
+
+
+def test_update_bug_in_jira_priority_already_set():
+    jira = Mock()
+    bug = Mock()
+    bug.bug_tasks = [Mock(importance='Critical', assignee=None, status='New')]
+
+    issue = Mock()
+    issue.key = 'TEST-1'
+    issue.fields.assignee = None
+    issue.fields.status.name = 'To Do'
+    issue.fields.priority.name = 'Highest'
+
+    priority_map = {'Critical': 'Highest'}
+    status_map = {'New': 'To Do'}
+
+    update_bug_in_jira(jira, bug, issue, [], {}, status_map, priority_map)
+    issue.update.assert_not_called()
+
+
+def test_update_bug_in_jira_no_priority_map():
+    jira = Mock()
+    bug = Mock()
+    bug.bug_tasks = [Mock(importance='Critical', assignee=None, status='New')]
+
+    issue = Mock()
+    issue.key = 'TEST-1'
+    issue.fields.assignee = None
+    issue.fields.status.name = 'To Do'
+    issue.fields.priority.name = 'Medium'
+
+    status_map = {'New': 'To Do'}
+
+    update_bug_in_jira(jira, bug, issue, [], {}, status_map)
+    issue.update.assert_not_called()

--- a/tests/test_lp_to_jira.py
+++ b/tests/test_lp_to_jira.py
@@ -317,7 +317,7 @@ def test_get_first_matching_assignee_mode2_no_user_map():
 
 
 def test_get_first_matching_assignee_mode3_no_match_falls_back():
-    """Mode 3: user_map exists, no match, sync_all_statuses=True → (None, first status)"""
+    """Mode 3: user_map exists, no match, sync_unmapped_users=True → (None, first status)"""
     bug = Mock()
     task = Mock()
     task.assignee = Mock(name='userid99')
@@ -326,7 +326,7 @@ def test_get_first_matching_assignee_mode3_no_match_falls_back():
     bug.bug_tasks = [task]
 
     assignee, status = get_first_matching_assignee(
-        bug, ['userid00', 'userid01'], sync_all_statuses=True)
+        bug, ['userid00', 'userid01'], sync_unmapped_users=True)
     assert assignee is None
     assert status == 'Confirmed'
 
@@ -341,24 +341,24 @@ def test_get_first_matching_assignee_mode3_match_still_returns_assignee():
     bug.bug_tasks = [task]
 
     assignee, status = get_first_matching_assignee(
-        bug, ['userid00', 'userid01'], sync_all_statuses=True)
+        bug, ['userid00', 'userid01'], sync_unmapped_users=True)
     assert assignee == 'userid00'
     assert status == 'In Progress'
 
 
 def test_get_first_matching_assignee_mode3_no_bug_tasks():
-    """Mode 3: sync_all_statuses=True but no bug tasks → (None, None)"""
+    """Mode 3: sync_unmapped_users=True but no bug tasks → (None, None)"""
     bug = Mock()
     bug.bug_tasks = []
 
     assignee, status = get_first_matching_assignee(
-        bug, ['userid00'], sync_all_statuses=True)
+        bug, ['userid00'], sync_unmapped_users=True)
     assert assignee is None
     assert status is None
 
 
-def test_update_bug_in_jira_sync_all_statuses():
-    """Mode 3: no assignee match but sync_all_statuses=True → status still updated"""
+def test_update_bug_in_jira_sync_unmapped_users():
+    """Mode 3: no assignee match but sync_unmapped_users=True → status still updated"""
     jira = Mock()
     bug = Mock()
     task = Mock()
@@ -378,5 +378,5 @@ def test_update_bug_in_jira_sync_all_statuses():
 
     update_bug_in_jira(
         jira, bug, issue, ['userid00'], {}, status_map,
-        sync_all_statuses=True)
+        sync_unmapped_users=True)
     jira.transition_issue.assert_called_once_with(issue, transition='To Do')

--- a/tests/test_lp_to_jira.py
+++ b/tests/test_lp_to_jira.py
@@ -9,6 +9,7 @@ from LpToJira.lp_to_jira import\
     get_lp_bug_pkg,\
     get_lp_bug_importance,\
     get_all_lp_project_bug_tasks,\
+    get_first_matching_assignee,\
     is_bug_in_jira,\
     lp_to_jira_bug,\
     update_bug_in_jira
@@ -272,3 +273,110 @@ def test_update_bug_in_jira_no_priority_map():
 
     update_bug_in_jira(jira, bug, issue, [], {}, status_map)
     issue.update.assert_not_called()
+
+
+def test_get_first_matching_assignee_mode1_match():
+    """Mode 1: user_map exists, assignee matches → return (assignee, status)"""
+    bug = Mock()
+    task = Mock()
+    task.assignee = Mock(name='userid00')
+    task.assignee.name = 'userid00'
+    task.status = 'In Progress'
+    bug.bug_tasks = [task]
+
+    assignee, status = get_first_matching_assignee(bug, ['userid00', 'userid01'])
+    assert assignee == 'userid00'
+    assert status == 'In Progress'
+
+
+def test_get_first_matching_assignee_mode1_no_match():
+    """Mode 1: user_map exists, no assignee match → return (None, None)"""
+    bug = Mock()
+    task = Mock()
+    task.assignee = Mock(name='userid99')
+    task.assignee.name = 'userid99'
+    task.status = 'In Progress'
+    bug.bug_tasks = [task]
+
+    assignee, status = get_first_matching_assignee(bug, ['userid00', 'userid01'])
+    assert assignee is None
+    assert status is None
+
+
+def test_get_first_matching_assignee_mode2_no_user_map():
+    """Mode 2: user_map empty → return (None, first status)"""
+    bug = Mock()
+    task = Mock()
+    task.assignee = None
+    task.status = 'Triaged'
+    bug.bug_tasks = [task]
+
+    assignee, status = get_first_matching_assignee(bug, [])
+    assert assignee is None
+    assert status == 'Triaged'
+
+
+def test_get_first_matching_assignee_mode3_no_match_falls_back():
+    """Mode 3: user_map exists, no match, sync_all_statuses=True → (None, first status)"""
+    bug = Mock()
+    task = Mock()
+    task.assignee = Mock(name='userid99')
+    task.assignee.name = 'userid99'
+    task.status = 'Confirmed'
+    bug.bug_tasks = [task]
+
+    assignee, status = get_first_matching_assignee(
+        bug, ['userid00', 'userid01'], sync_all_statuses=True)
+    assert assignee is None
+    assert status == 'Confirmed'
+
+
+def test_get_first_matching_assignee_mode3_match_still_returns_assignee():
+    """Mode 3: user_map exists, assignee matches → still return (assignee, status)"""
+    bug = Mock()
+    task = Mock()
+    task.assignee = Mock(name='userid00')
+    task.assignee.name = 'userid00'
+    task.status = 'In Progress'
+    bug.bug_tasks = [task]
+
+    assignee, status = get_first_matching_assignee(
+        bug, ['userid00', 'userid01'], sync_all_statuses=True)
+    assert assignee == 'userid00'
+    assert status == 'In Progress'
+
+
+def test_get_first_matching_assignee_mode3_no_bug_tasks():
+    """Mode 3: sync_all_statuses=True but no bug tasks → (None, None)"""
+    bug = Mock()
+    bug.bug_tasks = []
+
+    assignee, status = get_first_matching_assignee(
+        bug, ['userid00'], sync_all_statuses=True)
+    assert assignee is None
+    assert status is None
+
+
+def test_update_bug_in_jira_sync_all_statuses():
+    """Mode 3: no assignee match but sync_all_statuses=True → status still updated"""
+    jira = Mock()
+    bug = Mock()
+    task = Mock()
+    task.assignee = Mock(name='userid99')
+    task.assignee.name = 'userid99'
+    task.status = 'New'
+    task.importance = 'High'
+    bug.bug_tasks = [task]
+
+    issue = Mock()
+    issue.key = 'TEST-1'
+    issue.fields.assignee = None
+    issue.fields.status.name = 'In Progress'
+    issue.fields.priority = None
+
+    status_map = {'New': 'To Do'}
+
+    update_bug_in_jira(
+        jira, bug, issue, ['userid00'], {}, status_map,
+        sync_all_statuses=True)
+    jira.transition_issue.assert_called_once_with(issue, transition='To Do')

--- a/tests/test_milestone_sync.py
+++ b/tests/test_milestone_sync.py
@@ -245,7 +245,8 @@ def test_sync_milestone_to_jira_add_to_existing():
     call_args = issue.update.call_args
     fix_versions = call_args.kwargs['fields']['fixVersions']
     assert len(fix_versions) == 2
-    assert fix_versions[0] == existing_version
+    # Both versions should be dictionaries for proper JSON serialization
+    assert fix_versions[0] == {'name': 'ubuntu-20.04'}
     assert fix_versions[1] == {'name': 'ubuntu-22.04'}
 
 

--- a/tests/test_milestone_sync.py
+++ b/tests/test_milestone_sync.py
@@ -351,3 +351,70 @@ def test_lp_to_jira_bug_milestone_enabled():
     jira.get_project_version_by_name.assert_called_once_with('TEST', 'ubuntu-22.04')
     # Verify issue was updated with milestone
     jira_issue.update.assert_called_once()
+
+
+def test_sync_milestone_debug_disabled_by_default(capsys):
+    """Test that debug messages are not shown by default"""
+    jira = Mock()
+    
+    # Setup bug with milestone
+    bug = Mock()
+    milestone = Mock()
+    milestone.name = "ubuntu-22.04"
+    task = Mock()
+    task.milestone = milestone
+    bug.bug_tasks = [task]
+    
+    # Setup JIRA version
+    jira_version = Mock()
+    jira_version.name = "ubuntu-22.04"
+    jira.get_project_version_by_name = Mock(return_value=jira_version)
+    
+    # Setup issue without the milestone
+    issue = Mock()
+    issue.key = "TEST-123"
+    issue.fields = Mock()
+    issue.fields.fixVersions = []
+    
+    # Call without debug flag (default)
+    sync_milestone_to_jira(jira, bug, issue, "TEST")
+    
+    # Capture output
+    captured = capsys.readouterr()
+    
+    # Verify no DEBUG messages in output
+    assert "DEBUG:" not in captured.out
+
+
+def test_sync_milestone_debug_enabled(capsys):
+    """Test that debug messages are shown when debug flag is enabled"""
+    jira = Mock()
+    
+    # Setup bug with milestone
+    bug = Mock()
+    milestone = Mock()
+    milestone.name = "ubuntu-22.04"
+    task = Mock()
+    task.milestone = milestone
+    bug.bug_tasks = [task]
+    
+    # Setup JIRA version
+    jira_version = Mock()
+    jira_version.name = "ubuntu-22.04"
+    jira.get_project_version_by_name = Mock(return_value=jira_version)
+    
+    # Setup issue without the milestone
+    issue = Mock()
+    issue.key = "TEST-123"
+    issue.fields = Mock()
+    issue.fields.fixVersions = []
+    
+    # Call with debug flag enabled
+    sync_milestone_to_jira(jira, bug, issue, "TEST", debug=True)
+    
+    # Capture output
+    captured = capsys.readouterr()
+    
+    # Verify DEBUG messages are in output
+    assert "DEBUG: current_versions = []" in captured.out
+    assert "DEBUG: current_versions type = <class 'list'>" in captured.out

--- a/tests/test_milestone_sync.py
+++ b/tests/test_milestone_sync.py
@@ -1,0 +1,248 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from LpToJira.lp_to_jira import (
+    get_lp_bug_milestone,
+    ensure_jira_version,
+    sync_milestone_to_jira
+)
+
+
+def test_get_lp_bug_milestone_with_milestone():
+    """Test extracting milestone from a bug that has one"""
+    bug = Mock()
+    milestone = Mock()
+    milestone.name = "ubuntu-22.04"
+    
+    task = Mock()
+    task.milestone = milestone
+    bug.bug_tasks = [task]
+    
+    assert get_lp_bug_milestone(bug) == "ubuntu-22.04"
+
+
+def test_get_lp_bug_milestone_without_milestone():
+    """Test extracting milestone from a bug without one"""
+    bug = Mock()
+    task = Mock()
+    task.milestone = None
+    bug.bug_tasks = [task]
+    
+    assert get_lp_bug_milestone(bug) is None
+
+
+def test_get_lp_bug_milestone_no_milestone_attribute():
+    """Test extracting milestone when task doesn't have milestone attribute"""
+    bug = Mock()
+    task = Mock(spec=[])  # Task without milestone attribute
+    bug.bug_tasks = [task]
+    
+    assert get_lp_bug_milestone(bug) is None
+
+
+def test_get_lp_bug_milestone_multiple_tasks():
+    """Test extracting milestone from bug with multiple tasks"""
+    bug = Mock()
+    
+    milestone = Mock()
+    milestone.name = "ubuntu-22.04"
+    
+    task1 = Mock()
+    task1.milestone = None
+    
+    task2 = Mock()
+    task2.milestone = milestone
+    
+    bug.bug_tasks = [task1, task2]
+    
+    assert get_lp_bug_milestone(bug) == "ubuntu-22.04"
+
+
+def test_ensure_jira_version_existing():
+    """Test ensuring a version that already exists"""
+    jira = Mock()
+    existing_version = Mock()
+    existing_version.name = "ubuntu-22.04"
+    
+    jira.get_project_version_by_name = Mock(return_value=existing_version)
+    
+    result = ensure_jira_version(jira, "TEST", "ubuntu-22.04")
+    
+    assert result == existing_version
+    jira.get_project_version_by_name.assert_called_once_with("TEST", "ubuntu-22.04")
+    jira.create_version.assert_not_called()
+
+
+def test_ensure_jira_version_create_new():
+    """Test creating a new version when it doesn't exist"""
+    jira = Mock()
+    jira.get_project_version_by_name = Mock(side_effect=Exception("Not found"))
+    
+    new_version = Mock()
+    new_version.name = "ubuntu-22.04"
+    jira.create_version = Mock(return_value=new_version)
+    
+    result = ensure_jira_version(jira, "TEST", "ubuntu-22.04")
+    
+    assert result == new_version
+    jira.create_version.assert_called_once()
+    call_args = jira.create_version.call_args
+    assert call_args.kwargs['name'] == "ubuntu-22.04"
+    assert call_args.kwargs['project'] == "TEST"
+
+
+def test_ensure_jira_version_dry_run():
+    """Test ensuring a version in dry-run mode"""
+    jira = Mock()
+    jira.get_project_version_by_name = Mock(side_effect=Exception("Not found"))
+    
+    result = ensure_jira_version(jira, "TEST", "ubuntu-22.04", dry_run=True)
+    
+    assert result is None
+    jira.create_version.assert_not_called()
+
+
+def test_ensure_jira_version_none_name():
+    """Test ensuring a version with None name"""
+    jira = Mock()
+    
+    result = ensure_jira_version(jira, "TEST", None)
+    
+    assert result is None
+    jira.get_project_version_by_name.assert_not_called()
+
+
+def test_sync_milestone_to_jira_no_milestone():
+    """Test syncing when bug has no milestone"""
+    jira = Mock()
+    bug = Mock()
+    bug.bug_tasks = [Mock(milestone=None)]
+    issue = Mock()
+    
+    sync_milestone_to_jira(jira, bug, issue, "TEST")
+    
+    # Should not attempt to update issue
+    issue.update.assert_not_called()
+
+
+def test_sync_milestone_to_jira_with_milestone():
+    """Test syncing a milestone to JIRA"""
+    jira = Mock()
+    
+    # Setup bug with milestone
+    bug = Mock()
+    milestone = Mock()
+    milestone.name = "ubuntu-22.04"
+    task = Mock()
+    task.milestone = milestone
+    bug.bug_tasks = [task]
+    
+    # Setup JIRA version
+    jira_version = Mock()
+    jira_version.name = "ubuntu-22.04"
+    jira.get_project_version_by_name = Mock(return_value=jira_version)
+    
+    # Setup issue without the milestone
+    issue = Mock()
+    issue.key = "TEST-123"
+    issue.fields = Mock()
+    issue.fields.fixVersions = []
+    
+    sync_milestone_to_jira(jira, bug, issue, "TEST")
+    
+    # Should update the issue with the milestone
+    issue.update.assert_called_once()
+    call_args = issue.update.call_args
+    assert 'fixVersions' in call_args.kwargs['fields']
+    assert call_args.kwargs['fields']['fixVersions'] == [{'name': 'ubuntu-22.04'}]
+
+
+def test_sync_milestone_to_jira_already_has_milestone():
+    """Test syncing when issue already has the milestone"""
+    jira = Mock()
+    
+    # Setup bug with milestone
+    bug = Mock()
+    milestone = Mock()
+    milestone.name = "ubuntu-22.04"
+    task = Mock()
+    task.milestone = milestone
+    bug.bug_tasks = [task]
+    
+    # Setup JIRA version
+    jira_version = Mock()
+    jira_version.name = "ubuntu-22.04"
+    jira.get_project_version_by_name = Mock(return_value=jira_version)
+    
+    # Setup issue that already has the milestone
+    issue = Mock()
+    issue.key = "TEST-123"
+    issue.fields = Mock()
+    existing_version = Mock()
+    existing_version.name = "ubuntu-22.04"
+    issue.fields.fixVersions = [existing_version]
+    
+    sync_milestone_to_jira(jira, bug, issue, "TEST")
+    
+    # Should not update the issue since it already has the milestone
+    issue.update.assert_not_called()
+
+
+def test_sync_milestone_to_jira_dry_run():
+    """Test syncing in dry-run mode"""
+    jira = Mock()
+    
+    # Setup bug with milestone
+    bug = Mock()
+    milestone = Mock()
+    milestone.name = "ubuntu-22.04"
+    task = Mock()
+    task.milestone = milestone
+    bug.bug_tasks = [task]
+    
+    # Setup issue
+    issue = Mock()
+    issue.key = "TEST-123"
+    issue.fields = Mock()
+    issue.fields.fixVersions = []
+    
+    sync_milestone_to_jira(jira, bug, issue, "TEST", dry_run=True)
+    
+    # Should not update the issue in dry-run mode
+    issue.update.assert_not_called()
+
+
+def test_sync_milestone_to_jira_add_to_existing():
+    """Test syncing milestone when issue has other versions"""
+    jira = Mock()
+    
+    # Setup bug with milestone
+    bug = Mock()
+    milestone = Mock()
+    milestone.name = "ubuntu-22.04"
+    task = Mock()
+    task.milestone = milestone
+    bug.bug_tasks = [task]
+    
+    # Setup JIRA version
+    jira_version = Mock()
+    jira_version.name = "ubuntu-22.04"
+    jira.get_project_version_by_name = Mock(return_value=jira_version)
+    
+    # Setup issue with a different version
+    issue = Mock()
+    issue.key = "TEST-123"
+    issue.fields = Mock()
+    existing_version = Mock()
+    existing_version.name = "ubuntu-20.04"
+    issue.fields.fixVersions = [existing_version]
+    
+    sync_milestone_to_jira(jira, bug, issue, "TEST")
+    
+    # Should add the new milestone while keeping existing ones
+    issue.update.assert_called_once()
+    call_args = issue.update.call_args
+    fix_versions = call_args.kwargs['fields']['fixVersions']
+    assert len(fix_versions) == 2
+    assert fix_versions[0] == existing_version
+    assert fix_versions[1] == {'name': 'ubuntu-22.04'}

--- a/tests/test_milestone_sync.py
+++ b/tests/test_milestone_sync.py
@@ -288,6 +288,7 @@ def test_lp_to_jira_bug_milestone_disabled_by_default():
     opts.sync_milestone = False  # Disabled by default
     opts.user_map = {}
     opts.status_map = {}
+    opts.priority_map = {}
     opts.epic = None
     
     sync = {'jira_project': 'TEST'}
@@ -344,6 +345,7 @@ def test_lp_to_jira_bug_milestone_enabled():
     opts.sync_milestone = True  # Enabled
     opts.user_map = {}
     opts.status_map = {}
+    opts.priority_map = {}
     opts.epic = None
     
     sync = {'jira_project': 'TEST'}

--- a/tests/test_milestone_sync.py
+++ b/tests/test_milestone_sync.py
@@ -1,3 +1,6 @@
+import json
+import os
+import tempfile
 import pytest
 from unittest.mock import Mock, patch
 
@@ -5,7 +8,8 @@ from LpToJira.lp_to_jira import (
     get_lp_bug_milestone,
     ensure_jira_version,
     sync_milestone_to_jira,
-    lp_to_jira_bug
+    lp_to_jira_bug,
+    main
 )
 
 
@@ -418,3 +422,135 @@ def test_sync_milestone_debug_enabled(capsys):
     # Verify DEBUG messages are in output
     assert "DEBUG: current_versions = []" in captured.out
     assert "DEBUG: current_versions type = <class 'list'>" in captured.out
+
+
+def _write_config_tempfile(config_dict):
+    """Write config_dict as JSON to a NamedTemporaryFile and return its path."""
+    tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+    json.dump(config_dict, tmp)
+    tmp.flush()
+    tmp.close()
+    return tmp.name
+
+
+def _make_mock_infra():
+    """Return (mock_lp, mock_jira, mock_jira_api) with standard stubs."""
+    mock_lp = Mock()
+    mock_jira = Mock()
+    mock_jira_api = Mock()
+    mock_jira_api.server = "https://jira.example.com"
+    mock_jira_api.login = "user"
+    mock_jira_api.token = "token"
+    return mock_lp, mock_jira, mock_jira_api
+
+
+def _make_fake_tasks():
+    """Return a fake iterable of one bug task."""
+    fake_bug = Mock()
+    fake_bug_task = Mock()
+    fake_bug_task.bug = fake_bug
+    fake_tasks = Mock()
+    fake_tasks.__iter__ = Mock(return_value=iter([fake_bug_task]))
+    return fake_tasks
+
+
+def test_config_json_sync_milestone_sets_flag():
+    """Test that sync_milestone=true in config JSON is applied to opts passed to lp_to_jira_bug."""
+    config = {
+        "sync_milestone": True,
+        "status_map": {},
+        "user_map": {},
+        "project": [{"launchpad_project": "testproject", "jira_project": "TEST",
+                     "issue_type": "Bug", "component": "testcomponent"}]
+    }
+    config_path = _write_config_tempfile(config)
+    mock_lp, mock_jira, mock_jira_api = _make_mock_infra()
+    fake_tasks = _make_fake_tasks()
+
+    captured_opts = []
+
+    def capture_opts(lp, jira, bug, sync_config, opts):
+        captured_opts.append(opts)
+
+    try:
+        with patch("LpToJira.lp_to_jira.Launchpad") as mock_lp_class, \
+             patch("LpToJira.lp_to_jira.JIRA") as mock_jira_class, \
+             patch("LpToJira.lp_to_jira.jira_api", return_value=mock_jira_api), \
+             patch("LpToJira.lp_to_jira.get_all_lp_project_bug_tasks", return_value=fake_tasks), \
+             patch("LpToJira.lp_to_jira.lp_to_jira_bug", side_effect=capture_opts):
+            mock_lp_class.login_with.return_value = mock_lp
+            mock_jira_class.return_value = mock_jira
+            main(["--config-json", config_path])
+    finally:
+        os.unlink(config_path)
+
+    assert len(captured_opts) == 1
+    assert captured_opts[0].sync_milestone is True
+
+
+def test_config_json_sync_milestone_disabled():
+    """Test that sync_milestone=false in config JSON keeps milestone syncing disabled."""
+    config = {
+        "sync_milestone": False,
+        "status_map": {},
+        "user_map": {},
+        "project": [{"launchpad_project": "testproject", "jira_project": "TEST",
+                     "issue_type": "Bug", "component": "testcomponent"}]
+    }
+    config_path = _write_config_tempfile(config)
+    mock_lp, mock_jira, mock_jira_api = _make_mock_infra()
+    fake_tasks = _make_fake_tasks()
+
+    captured_opts = []
+
+    def capture_opts(lp, jira, bug, sync_config, opts):
+        captured_opts.append(opts)
+
+    try:
+        with patch("LpToJira.lp_to_jira.Launchpad") as mock_lp_class, \
+             patch("LpToJira.lp_to_jira.JIRA") as mock_jira_class, \
+             patch("LpToJira.lp_to_jira.jira_api", return_value=mock_jira_api), \
+             patch("LpToJira.lp_to_jira.get_all_lp_project_bug_tasks", return_value=fake_tasks), \
+             patch("LpToJira.lp_to_jira.lp_to_jira_bug", side_effect=capture_opts):
+            mock_lp_class.login_with.return_value = mock_lp
+            mock_jira_class.return_value = mock_jira
+            main(["--config-json", config_path])
+    finally:
+        os.unlink(config_path)
+
+    assert len(captured_opts) == 1
+    assert captured_opts[0].sync_milestone is False
+
+
+def test_config_json_without_sync_milestone_key():
+    """Test that omitting sync_milestone in config JSON leaves the CLI default (False)."""
+    config = {
+        "status_map": {},
+        "user_map": {},
+        "project": [{"launchpad_project": "testproject", "jira_project": "TEST",
+                     "issue_type": "Bug", "component": "testcomponent"}]
+    }
+    config_path = _write_config_tempfile(config)
+    mock_lp, mock_jira, mock_jira_api = _make_mock_infra()
+    fake_tasks = _make_fake_tasks()
+
+    captured_opts = []
+
+    def capture_opts(lp, jira, bug, sync_config, opts):
+        captured_opts.append(opts)
+
+    try:
+        with patch("LpToJira.lp_to_jira.Launchpad") as mock_lp_class, \
+             patch("LpToJira.lp_to_jira.JIRA") as mock_jira_class, \
+             patch("LpToJira.lp_to_jira.jira_api", return_value=mock_jira_api), \
+             patch("LpToJira.lp_to_jira.get_all_lp_project_bug_tasks", return_value=fake_tasks), \
+             patch("LpToJira.lp_to_jira.lp_to_jira_bug", side_effect=capture_opts):
+            mock_lp_class.login_with.return_value = mock_lp
+            mock_jira_class.return_value = mock_jira
+            main(["--config-json", config_path])
+    finally:
+        os.unlink(config_path)
+
+    assert len(captured_opts) == 1
+    # CLI default for --sync-milestone is False
+    assert captured_opts[0].sync_milestone is False


### PR DESCRIPTION
In lp_to_jira_bug(), it should allow specifying empty user_map to sync all bugs from any assignee. But there is bug in that user_map setup that break this feature.

Moving the assignee initial value only during build build_jira_issue to solve this issue